### PR TITLE
Always reload on prepare

### DIFF
--- a/lib/consent/railtie.rb
+++ b/lib/consent/railtie.rb
@@ -13,14 +13,10 @@ module Consent
       )
     end
 
-    config.after_initialize do |app|
-      app.config.consent.execute
-    end
-
     initializer 'initialize consent permissions reloading' do |app|
       app.reloaders << config.consent
       ActiveSupport::Dependencies.autoload_paths -= config.consent.paths
-      config.to_prepare { app.config.consent.execute_if_updated }
+      config.to_prepare { app.config.consent.execute }
     end
   end
 end


### PR DESCRIPTION
Reloading only when permisions file change breaks the reference of the
subject in consent. Consider the following scenario:

1. Rails is loaded, permissions to User also are loaded
2. Any file in app changes, User model is reloaded
3. Consent has a reference to the old User definition, with a different
   object_id

![image](https://user-images.githubusercontent.com/8156/69758177-8decb900-113d-11ea-8c0c-f49a9581b75f.png)
